### PR TITLE
refactor: modularize effects

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -4,7 +4,6 @@ class EffectsManager {
     this.activeEffects = [];
     this.settingPointForEffectId = null;
     this.paintingEffectId = null;
-    this.MAX_EFFECTS = 15;
     this.TWO_PI = Math.PI * 2;
     this.EFFECT_TYPE_BREATHING = 1;
     this.EFFECT_TYPE_MASK_SWAY = 2;
@@ -63,132 +62,16 @@ class EffectsManager {
   }
 
   createEffect(type) {
-    if (type === 'maskSway') {
-      return {
-        id: Date.now() + Math.random(),
-        type,
-        strength: 0.005, // Reduzido de 0.008 para movimento mais sutil
-        speed: 1.0, // Reduzido de 1.5 para movimento mais lento e suave
-        noiseScale: 0.8, // Reduzido de 1.5 para ondas mais amplas e suaves
-        align: 0.5, // Não usado no novo algoritmo, mas mantido
-        wind: { x: 0.005, y: 0.002 }, // Reduzido para drift mais sutil
-        phase: 0.0,
-        showPreview: true, // Será atualizado baseado no estado do collapse
-        expanded: true,
-        // Canvas e contexto próprios para a máscara deste efeito
-        maskCanvas: null,
-        maskCtx: null,
-        maskTexture: null,
-        brush: {
-          size: 20,
-          hardness: 1.0,
-          erase: false
-        },
-        exclusionMask: {
-          enabled: false,
-          brush: {
-            size: 30,
-            hardness: 0.8,
-            erase: false
-          }
-        }
-      };
-    } else if (type === 'wave') {
-      return {
-        id: Date.now() + Math.random(),
-        type,
-        strength: 0.015,
-        radius: 0.3,
-        softness: 0.3,
-        speed: 2.0,
-        phase: 0.0,
-        marker: { x: 0.5, y: 0.5 },
-        showPreview: true,
-        expanded: true,
-        waveSize: 15.0,           // Tamanho das ondas
-        waveDirection: { x: 1.0, y: 0.0 }, // Direção das ondas (horizontal por padrão)
-        // Máscara pintável para definir área afetada
-        maskCanvas: null,
-        maskCtx: null,
-        maskTexture: null,
-        brush: {
-          size: 20,
-          hardness: 1.0,
-          erase: false
-        },
-        exclusionMask: {
-          enabled: false,
-          brush: {
-            size: 30,
-            hardness: 0.8,
-            erase: false
-          }
-        }
-      };
-    } else if (type === 'saber') {
-      return {
-        id: Date.now() + Math.random(),
-        type,
-        strength: 0.025,          // Reduzir de 0.040 para 0.025 - ainda visível mas menos intenso
-        speed: 1.2,               // fireSpeed
-        phase: 0.0,
-        turbulence: 0.8,          // noiseMultiplier/distortionPower
-        color: '#ff6b35',         // outerColorBase
-        fuzziness: 0.4,           // fuzziness (suavização das bordas)
-        baseSize: 1.2,            // baseSize (largura da chama)
-        verticalFalloff: 2.0,     // innerVerticalFalloff (como a chama diminui verticalmente)
-        pulseIntensity: 1.0,      // intensidade da pulsação de cor
-        showPreview: true,
-        expanded: true,
-        // Máscara pintável para definir área afetada
-        maskCanvas: null,
-        maskCtx: null,
-        maskTexture: null,
-        brush: {
-          size: 30,
-          hardness: 0.8,
-          erase: false
-        },
-        exclusionMask: {
-          enabled: false,
-          brush: {
-            size: 30,
-            hardness: 0.8,
-            erase: false
-          }
-        }
-      };
-    } else {
-      return {
-        id: Date.now() + Math.random(),
-        type,
-        strength: 0.03,
-        radius: 0.4,
-        softness: 0.4,
-        speed: 1.5,
-        phase: 0.0,
-        marker: { x: 0.5, y: 0.5 },
-        showPreview: true, // Será atualizado baseado no estado do collapse
-        expanded: true,
-        exclusionMask: {
-          enabled: false,
-          brush: {
-            size: 30,
-            hardness: 0.8,
-            erase: false
-          }
-        }
-      };
+    // Delegate creation to the global registry for better modularity
+    const effect = window.effectsRegistry.create(type);
+    if (!effect) {
+      console.warn(`Effect type "${type}" is not registered.`);
     }
+    return effect;
   }
 
   addEffect(type) {
     console.log('Adicionando efeito:', type);
-    
-    if (this.activeEffects.length >= this.MAX_EFFECTS) {
-      this.showNotification('Limite de efeitos atingido.', 'warning');
-      return;
-    }
 
     const newEffect = this.createEffect(type);
     if (newEffect) {

--- a/effects/breathing.js
+++ b/effects/breathing.js
@@ -1,0 +1,21 @@
+// Breathing effect definition
+window.effectsRegistry.register('breathing', () => ({
+  id: Date.now() + Math.random(),
+  type: 'breathing',
+  strength: 0.03,
+  radius: 0.4,
+  softness: 0.4,
+  speed: 1.5,
+  phase: 0.0,
+  marker: { x: 0.5, y: 0.5 },
+  showPreview: true,
+  expanded: true,
+  exclusionMask: {
+    enabled: false,
+    brush: {
+      size: 30,
+      hardness: 0.8,
+      erase: false
+    }
+  }
+}));

--- a/effects/maskSway.js
+++ b/effects/maskSway.js
@@ -1,0 +1,29 @@
+// Mask sway (hair) effect definition
+window.effectsRegistry.register('maskSway', () => ({
+  id: Date.now() + Math.random(),
+  type: 'maskSway',
+  strength: 0.005,
+  speed: 1.0,
+  noiseScale: 0.8,
+  align: 0.5,
+  wind: { x: 0.005, y: 0.002 },
+  phase: 0.0,
+  showPreview: true,
+  expanded: true,
+  maskCanvas: null,
+  maskCtx: null,
+  maskTexture: null,
+  brush: {
+    size: 20,
+    hardness: 1.0,
+    erase: false
+  },
+  exclusionMask: {
+    enabled: false,
+    brush: {
+      size: 30,
+      hardness: 0.8,
+      erase: false
+    }
+  }
+}));

--- a/effects/registry.js
+++ b/effects/registry.js
@@ -1,0 +1,23 @@
+// Global registry for effect factory functions
+window.effectsRegistry = {
+  _factories: {},
+
+  /**
+   * Register a new effect factory under the given type.
+   * @param {string} type
+   * @param {Function} factory
+   */
+  register(type, factory) {
+    this._factories[type] = factory;
+  },
+
+  /**
+   * Create an effect instance by type.
+   * @param {string} type
+   * @returns {Object|null}
+   */
+  create(type) {
+    const factory = this._factories[type];
+    return factory ? factory() : null;
+  }
+};

--- a/effects/saber.js
+++ b/effects/saber.js
@@ -1,0 +1,32 @@
+// Saber effect definition
+window.effectsRegistry.register('saber', () => ({
+  id: Date.now() + Math.random(),
+  type: 'saber',
+  strength: 0.025,
+  speed: 1.2,
+  phase: 0.0,
+  turbulence: 0.8,
+  color: '#ff6b35',
+  fuzziness: 0.4,
+  baseSize: 1.2,
+  verticalFalloff: 2.0,
+  pulseIntensity: 1.0,
+  showPreview: true,
+  expanded: true,
+  maskCanvas: null,
+  maskCtx: null,
+  maskTexture: null,
+  brush: {
+    size: 30,
+    hardness: 0.8,
+    erase: false
+  },
+  exclusionMask: {
+    enabled: false,
+    brush: {
+      size: 30,
+      hardness: 0.8,
+      erase: false
+    }
+  }
+}));

--- a/effects/wave.js
+++ b/effects/wave.js
@@ -1,0 +1,31 @@
+// Wave effect definition
+window.effectsRegistry.register('wave', () => ({
+  id: Date.now() + Math.random(),
+  type: 'wave',
+  strength: 0.015,
+  radius: 0.3,
+  softness: 0.3,
+  speed: 2.0,
+  phase: 0.0,
+  marker: { x: 0.5, y: 0.5 },
+  showPreview: true,
+  expanded: true,
+  waveSize: 15.0,
+  waveDirection: { x: 1.0, y: 0.0 },
+  maskCanvas: null,
+  maskCtx: null,
+  maskTexture: null,
+  brush: {
+    size: 20,
+    hardness: 1.0,
+    erase: false
+  },
+  exclusionMask: {
+    enabled: false,
+    brush: {
+      size: 30,
+      hardness: 0.8,
+      erase: false
+    }
+  }
+}));

--- a/index.html
+++ b/index.html
@@ -219,6 +219,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gif.js/0.2.0/gif.js"></script>
   <script src="shaders.js"></script>
   <script src="canvas-controls.js"></script>
+  <script src="effects/registry.js"></script>
+  <script src="effects/breathing.js"></script>
+  <script src="effects/maskSway.js"></script>
+  <script src="effects/wave.js"></script>
+  <script src="effects/saber.js"></script>
   <script src="effects.js"></script>
   <script src="webgl-renderer.js"></script>
   <script src="export-utils.js"></script>

--- a/shaders.js
+++ b/shaders.js
@@ -11,7 +11,7 @@ const Shaders = {
 
   fragment: `
     precision mediump float;
-    const int MAX_EFFECTS = 15;
+    const int MAX_EFFECTS = 50;
     const int EFFECT_TYPE_BREATHING = 1;
     const int EFFECT_TYPE_MASK_SWAY = 2;
     const int EFFECT_TYPE_EXCLUSION_MASK = 3;

--- a/webgl-renderer.js
+++ b/webgl-renderer.js
@@ -1,4 +1,6 @@
 // Renderizador WebGL
+const MAX_EFFECTS = 50;
+
 class WebGLRenderer {
   constructor() {
     this.gl = null;
@@ -626,19 +628,19 @@ class WebGLRenderer {
 
     // Obter efeitos ativos da lista global
     const effects = effectsManager.activeEffects;
-    const n = effects.length;
+    const n = Math.min(effects.length, MAX_EFFECTS);
     
     // Prepare effect data
-    const effectTypes = new Int32Array(15);
-    const effectMarkers = new Float32Array(15 * 2);
-    const effectStrengths = new Float32Array(15);
-    const effectRadii = new Float32Array(15);
-    const effectSoft = new Float32Array(15);
-    const effectSpeeds = new Float32Array(15);
-    const effectPhases = new Float32Array(15);
-    const effectParamsA = new Float32Array(15 * 4);
-    const effectParamsB = new Float32Array(15 * 4);
-    const effectColors = new Float32Array(15 * 4); // Para cores RGBA dos efeitos
+    const effectTypes = new Int32Array(MAX_EFFECTS);
+    const effectMarkers = new Float32Array(MAX_EFFECTS * 2);
+    const effectStrengths = new Float32Array(MAX_EFFECTS);
+    const effectRadii = new Float32Array(MAX_EFFECTS);
+    const effectSoft = new Float32Array(MAX_EFFECTS);
+    const effectSpeeds = new Float32Array(MAX_EFFECTS);
+    const effectPhases = new Float32Array(MAX_EFFECTS);
+    const effectParamsA = new Float32Array(MAX_EFFECTS * 4);
+    const effectParamsB = new Float32Array(MAX_EFFECTS * 4);
+    const effectColors = new Float32Array(MAX_EFFECTS * 4); // Para cores RGBA dos efeitos
 
     for (let i = 0; i < n; i++) {
       const e = effects[i];


### PR DESCRIPTION
## Summary
- introduce a global registry for effect factories
- split effect definitions into individual modules
- raise WebGL effect capacity and wire renderer to new registry

## Testing
- `node --check effects/registry.js`
- `node --check effects.js`
- `node --check webgl-renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_68998bf07de48320bb1e12282bfdabbc